### PR TITLE
fix: 🐛 permissions and s3 config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,15 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## 1.0.1 - 2018-10-10
+https://github.com/philips-software/terraform-aws-cloudfront-s3/tags/1.0.1
+### Added
+- Lifecycle rule in case versioning is enabled
+
+### Changed
+- Remove list permission from S3 policy
+- Disable S3 website configuration
+
 ## 1.0.0
 https://github.com/philips-software/terraform-aws-cloudfront-s3/tags/1.0.0
 - Initial version

--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@ By default a route53 record will be created for the provided dns_name. The subdo
 ```
 module "cloudfront" {
   source = "philips-software/cloudfront-s3/aws"
-  version = "1.0.0"
+  version = "1.0.1"
 
   # Or via github
-  # source = "github.com/philips-software/aws-terraform-cloudfront-s3?ref=1.0.0"
+  # source = "github.com/philips-software/aws-terraform-cloudfront-s3?ref=1.0.1"
 
   environment = "forest"
   name = "default"

--- a/variables.tf
+++ b/variables.tf
@@ -101,7 +101,7 @@ variable "bucket_acl" {
 }
 
 variable "bucket_versioning" {
-  description = "A state of versioning (documented below)"
+  description = "A state of versioning"
   default     = false
 }
 


### PR DESCRIPTION
## Rational

- Lifecycle rule in case versioning is enabled:
Without it, old versions will live forever which will increase maintenance efforts.

- Remove list permission from S3 policy:
It is not needed.

- Disable S3 website configuration:
It is not needed.

I did not do the sensible defaults (compression defaults true, etc) part since the team wants to follow AWS defaults.

Fixes #1 